### PR TITLE
Fix render_to_string() calls with unexpected context_instance param

### DIFF
--- a/authority/admin.py
+++ b/authority/admin.py
@@ -122,8 +122,7 @@ def edit_permissions(modeladmin, request, queryset):
         "admin/%s/permission_change_form.html" % app_label,
         "admin/permission_change_form.html"
     ])
-    return render_to_response(template_name, context,
-                              context_instance=template.RequestContext(request))
+    return render_to_response(template_name, context, request)
 edit_permissions.short_description = _("Edit permissions for selected %(verbose_name_plural)s")
 
 

--- a/authority/templatetags/permissions.py
+++ b/authority/templatetags/permissions.py
@@ -190,8 +190,8 @@ class PermissionFormNode(ResolverNode):
                         approved=self.approved,
                         initial=dict(codename=perm, user=request.user.username)),
                 }
-        return template.loader.render_to_string(
-            template_name, extra_context, context_instance=template.RequestContext(request))
+        return template.loader.render_to_string(template_name, extra_context,
+                                                request)
 
 
 @register.tag

--- a/authority/views.py
+++ b/authority/views.py
@@ -2,7 +2,6 @@ from django.shortcuts import render_to_response, get_object_or_404
 from django.http import HttpResponseRedirect, HttpResponseForbidden
 from django.apps import apps
 from django.utils.translation import ugettext as _
-from django.template.context import RequestContext
 from django.template import loader
 from django.contrib.auth.decorators import login_required
 
@@ -63,8 +62,7 @@ def add_permission(request, app_label, module_name, pk, approved=False,
     }
     if extra_context:
         context.update(extra_context)
-    return render_to_response(template_name, context,
-                              context_instance=RequestContext(request))
+    return render_to_response(template_name, context, request)
 
 
 @login_required
@@ -110,5 +108,5 @@ def permission_denied(request, template_name=None, extra_context=None):
     }
     if extra_context:
         context.update(extra_context)
-    return HttpResponseForbidden(loader.render_to_string(template_name, context,
-                                 context_instance=RequestContext(request)))
+    return HttpResponseForbidden(loader.render_to_string(template_name,
+                                                         context, request))


### PR DESCRIPTION
Further fix to achieve Django 1.10 compatibility
